### PR TITLE
fix docker run instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Build the image by running:
 
 View help files:
 
-`docker run -it --rm rovecom/swagger-tools --help`
+`docker run -it --rm rovecom/swagger-tools swagger-tools --help`
 
 Validate a file:
 
-`docker run -it --rm -v ${pwd}:/work rovecom/swagger-tools validate swagger.yaml`
+`docker run -it --rm -v $(pwd):/work rovecom/swagger-tools swagger-tools validate swagger.yaml`


### PR DESCRIPTION
command must be specified since ENTRYPOINT was removed in 966f9c3:

```
$ docker run -it --rm rovecom/swagger-tools --help
docker: Error response from daemon: oci runtime error: container_linux.go:262: starting container process caused "exec: \"--help\": executable file not found in $PATH".
```

pwd isn't executed automatically:

```
$ docker run -it --rm -v ${pwd}:/work rovecom/swagger-tools validate swagger.yaml
docker: Error response from daemon: invalid volume spec ":/work": invalid volume specification: ':/work'.
See 'docker run --help'.
```
